### PR TITLE
Change isAlbum query to filter

### DIFF
--- a/src/users/playlist/dto/isAlbum-input-dto.ts
+++ b/src/users/playlist/dto/isAlbum-input-dto.ts
@@ -1,0 +1,14 @@
+import { IsEnum } from 'class-validator';
+
+import { Optional } from '@nestjs/common';
+
+import { PlaylistType } from '../../schema/playlist.schema';
+
+export class FilterInputQueryDto {
+  /**
+   * Retuns only albums or only playlists or both, 1 for albums, 0 for playlists, 2 for both
+   */
+  @Optional()
+  @IsEnum(PlaylistType)
+  filter: PlaylistType = PlaylistType.all;
+}

--- a/src/users/playlist/dto/playlist-response.dto.ts
+++ b/src/users/playlist/dto/playlist-response.dto.ts
@@ -9,6 +9,7 @@ export class GetPlaylistInfoResponseDto extends PickType(Playlist, [
   'name',
   'description',
   'coverImage',
+  'isAlbum',
 ] as const) {
   /**
    * username of the owner

--- a/src/users/playlist/playlists.controller.ts
+++ b/src/users/playlist/playlists.controller.ts
@@ -25,6 +25,7 @@ import { JoiValidationPipe } from '../../utils/joiValidation.pipe';
 import { UtilsService } from '../../utils/utils.service';
 import { CreatePlaylistDto } from '../dto/create-playlist.dto';
 import { EditPlaylistDto } from '../dto/edit-playlist.dto';
+import { FilterInputQueryDto } from './dto/isAlbum-input-dto';
 import {
   AddMusicToPlaylistBodyDto,
   AddMusicToPlaylistResponseDto,
@@ -50,9 +51,10 @@ export class PlaylistsController {
 
   @Get('all')
   @ApiQuery({
-    name: 'isAlbum',
-    description: 'If true, return only albums',
-    type: Boolean,
+    name: 'filter',
+    required: false,
+    description: '"album" for albums, "playlist" for playlists, "all" for both',
+    type: String,
   })
   @ApiResponse({
     status: 200,
@@ -61,12 +63,13 @@ export class PlaylistsController {
   })
   async getPlaylists(
     @Req() req,
-    @Query('isAlbum') isAlbum: boolean = false,
+    @Query()
+    query: FilterInputQueryDto,
   ): Promise<GetPlaylistInfoResponseDto[]> {
     this.utilsService.validateMongoId(req.user.userId);
     return await this.playlistService.getPlaylistsInfo(
       req.user.userId,
-      isAlbum,
+      query.filter,
     );
   }
 

--- a/src/users/playlist/playlists.service.ts
+++ b/src/users/playlist/playlists.service.ts
@@ -9,7 +9,11 @@ import { InjectModel } from '@nestjs/mongoose';
 
 import { CreatePlaylistDto } from '../dto/create-playlist.dto';
 import { EditPlaylistDto } from '../dto/edit-playlist.dto';
-import { Playlist, PlaylistDocument } from '../schema/playlist.schema';
+import {
+  Playlist,
+  PlaylistDocument,
+  PlaylistType,
+} from '../schema/playlist.schema';
 import {
   AddMusicToPlaylistResponseDto,
   MusicsInPlaylistResponseDto,
@@ -38,6 +42,7 @@ export class PlaylistsService {
         description: 1,
         coverImage: 1,
         userId: 1,
+        isAlbum: 1,
       })
       .populate('userId', { username: 1 });
 
@@ -57,6 +62,7 @@ export class PlaylistsService {
           ? (playlist.userId as any).username
           : '',
       creatorId: playlist.userId._id,
+      isAlbum: playlist.isAlbum,
     };
 
     return res;
@@ -64,12 +70,14 @@ export class PlaylistsService {
 
   async getPlaylistsInfo(
     userId: Types.ObjectId,
-    isAlbum: boolean,
+    isAlbum: PlaylistType = PlaylistType.all,
   ): Promise<GetPlaylistInfoResponseDto[]> {
     // Initialize filter
     const filter = { userId: userId };
-    if (isAlbum) {
+    if (isAlbum === PlaylistType.album) {
       filter['isAlbum'] = true;
+    } else if (isAlbum === PlaylistType.playlist) {
+      filter['isAlbum'] = false;
     }
 
     // Get playlists
@@ -79,6 +87,7 @@ export class PlaylistsService {
         description: 1,
         coverImage: 1,
         userId: 1,
+        isAlbum: 1,
       })
       .populate('userId', { username: 1 });
 
@@ -94,6 +103,7 @@ export class PlaylistsService {
             ? (playlist.userId as any).username
             : '',
         creatorId: playlist.userId._id,
+        isAlbum: playlist.isAlbum,
       });
     }
     return res;

--- a/src/users/schema/playlist.schema.ts
+++ b/src/users/schema/playlist.schema.ts
@@ -8,6 +8,12 @@ import { User } from './users.schema';
 
 export type PlaylistDocument = Playlist & Document;
 
+export enum PlaylistType {
+  playlist = 'playlist',
+  album = 'album',
+  all = 'all',
+}
+
 @Schema()
 export class Playlist {
   /**


### PR DESCRIPTION
From @tinnakitudsa to be able to choose to filter only playlist, albums or both. I changed `isAlbum` query to be `filter` which accepts string of `album`, `playlist` or `all`.

To distinct the music playlists output, I also add `isAlbum` field to those response.